### PR TITLE
fix: atomic finance blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Discreet log contract is an oracle contract scheme proposed by Tadge in [this wh
 * [DLC by Optech](https://bitcoinops.org/en/topics/discreet-log-contracts/)
 * [Discreet Log Contract by River](https://river.com/learn/terms/d/discreet-log-contract-dlc/)
 * [DLC on Lightning](https://medium.com/crypto-garage/dlc-on-lightning-cb5d191f6e64)
-* [A Layperson's Guide to Discreet Log Contracts](https://atomic.finance/blog/a-laypersons-guide-to-discreet-log-contracts-atomic-yield-series-part-3/)
+* [A Layperson's Guide to Discreet Log Contracts](https://atomic.finance/blog/discreet-log-contracts/)
 * [Bitcoin Oracle Contracts: Discreet Log Contracts in Practice](https://ieeexplore.ieee.org/document/9805512)
 * [Oracle-based Conditional payments on Bitcoin](https://blog.lnmarkets.com/oracle-based-conditionnal-payment-on-bitcoin-2/)
 * [DLCVM: Generalized, Unboundedly Scalable Computation on Bitcoin](https://dlcvm.tiiny.site/)


### PR DESCRIPTION
slug for atomic finance `A Layperson's Guide to Discreet Log Contracts` blog post has changed