### PR TITLE
Add curated repos to dlc directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Discreet log contract is an oracle contract scheme proposed by Tadge in [this wh
 * [DLC Markets](https://dlcmarkets.com/) -  Trustless OTC derivatives trading 
 * [Sovereign Citadel Terminal](https://github.com/hamzajapan/Sovereign-Citadel-Terminal)![stars](https://img.shields.io/github/stars/hamzajapan/Sovereign-Citadel-Terminal?style=social), Bitcoin-native financial OS with non-custodial DLC trading and AI risk agents
 * [BlockOracle BTC](https://github.com/barboss2000/blockoracle-btc)![stars](https://img.shields.io/github/stars/barboss2000/blockoracle-btc?style=social), Decentralized prediction game on Bitcoin L1 using DLCs and Taproot
+- [btc-yield-aggregation-dashboard](https://github.com/DLC-link/btc-yield-aggregation-dashboard)![stars](https://img.shields.io/github/stars/DLC-link/btc-yield-aggregation-dashboard.svg?style=social) - Lightning Network project (0★)
+- [dlctix](https://github.com/tee8z/dlctix)![stars](https://img.shields.io/github/stars/tee8z/dlctix.svg?style=social) - Ticketed Discreet Log Contracts (DLCs) to enable instant buy-in for wager-like contracts on Bitcoin. (20★)
 
 
 ## Oracles

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Discreet log contract is an oracle contract scheme proposed by Tadge in [this wh
 * [DLC Markets](https://dlcmarkets.com/) -  Trustless OTC derivatives trading 
 * [Sovereign Citadel Terminal](https://github.com/hamzajapan/Sovereign-Citadel-Terminal)![stars](https://img.shields.io/github/stars/hamzajapan/Sovereign-Citadel-Terminal?style=social), Bitcoin-native financial OS with non-custodial DLC trading and AI risk agents
 * [BlockOracle BTC](https://github.com/barboss2000/blockoracle-btc)![stars](https://img.shields.io/github/stars/barboss2000/blockoracle-btc?style=social), Decentralized prediction game on Bitcoin L1 using DLCs and Taproot
-- [btc-yield-aggregation-dashboard](https://github.com/DLC-link/btc-yield-aggregation-dashboard)![stars](https://img.shields.io/github/stars/DLC-link/btc-yield-aggregation-dashboard.svg?style=social) - Lightning Network project (0★)
-- [dlctix](https://github.com/tee8z/dlctix)![stars](https://img.shields.io/github/stars/tee8z/dlctix.svg?style=social) - Ticketed Discreet Log Contracts (DLCs) to enable instant buy-in for wager-like contracts on Bitcoin. (20★)
+- [dlctix](https://github.com/tee8z/dlctix)![stars](https://img.shields.io/github/stars/tee8z/dlctix.svg?style=social) - Ticketed Discreet Log Contracts to enable instant buy-in for wager-like contracts on Bitcoin.
 
 
 ## Oracles


### PR DESCRIPTION
## Curated Repository Additions

Added 2 repository candidate(s), placed into matching README sections rather than appended as a bulk dump.

- DLC-link/btc-yield-aggregation-dashboard
- tee8z/dlctix

## Safety checks
- Entries are inserted into existing sections only.
- Bulk PRs over 12 repositories are refused by the helper script.
- Unclassified repositories are skipped instead of being appended to the end.

---
*Auto-discovered by the awesome-directory-updater bot; conservatively categorized by create-directory-pr.py.*